### PR TITLE
Limit FFT size to 2^32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.1
+
+- Limit FFT size to 2^32, so that int literals can be small enough for JS
+  compatibility.
+
 ## 1.1.0
 
 - Add support for FFTs of any size, not just powers of two.

--- a/lib/impl.dart
+++ b/lib/impl.dart
@@ -42,6 +42,9 @@ abstract class FFT {
     if (size <= 0) {
       throw ArgumentError('FFT size must be greater than 0.', 'size');
     }
+    if (size > 0x100000000) {
+      throw ArgumentError('FFT size is limited to 2^32.', 'size');
+    }
     if (size == 2) {
       return Fixed2FFT();
     }
@@ -226,16 +229,15 @@ class Radix2FFT extends FFT {
     // Bit reverse permutation.
     final n = _size;
     final n2 = n >>> 1;
-    final shift = 64 - _bits;
+    final shift = 32 - _bits;
     for (int i = 0; i < n; ++i) {
       // Calculate bit reversal.
       int j = i;
-      j = ((j >>> 32) & 0x00000000FFFFFFFF) | (j << 32);
-      j = ((j >>> 16) & 0x0000FFFF0000FFFF) | ((j & 0x0000FFFF0000FFFF) << 16);
-      j = ((j >>> 8) & 0x00FF00FF00FF00FF) | ((j & 0x00FF00FF00FF00FF) << 8);
-      j = ((j >>> 4) & 0x0F0F0F0F0F0F0F0F) | ((j & 0x0F0F0F0F0F0F0F0F) << 4);
-      j = ((j >>> 2) & 0x3333333333333333) | ((j & 0x3333333333333333) << 2);
-      j = ((j >>> 1) & 0x5555555555555555) | ((j & 0x5555555555555555) << 1);
+      j = ((j >>> 16) & 0x0000FFFF) | ((j & 0x0000FFFF) << 16);
+      j = ((j >>> 8) & 0x00FF00FF) | ((j & 0x00FF00FF) << 8);
+      j = ((j >>> 4) & 0x0F0F0F0F) | ((j & 0x0F0F0F0F) << 4);
+      j = ((j >>> 2) & 0x33333333) | ((j & 0x33333333) << 2);
+      j = ((j >>> 1) & 0x55555555) | ((j & 0x55555555) << 1);
       j >>>= shift;
       // Permute.
       if (j < i) {

--- a/lib/util.dart
+++ b/lib/util.dart
@@ -214,13 +214,15 @@ bool primePaddingHeuristic(int n) {
 }
 
 /// Returns the highest set bit of [x], where [x] is a power of 2.
+///
+/// Only supports [x] below 2^48, for compatibility with JS.
 int highestBit(int x) {
-  return ((x & 0xAAAAAAAAAAAAAAAA) != 0 ? 1 : 0) |
-      ((x & 0xCCCCCCCCCCCCCCCC) != 0 ? 2 : 0) |
-      ((x & 0xF0F0F0F0F0F0F0F0) != 0 ? 4 : 0) |
-      ((x & 0xFF00FF00FF00FF00) != 0 ? 8 : 0) |
-      ((x & 0xFFFF0000FFFF0000) != 0 ? 16 : 0) |
-      ((x & 0xFFFFFFFF00000000) != 0 ? 32 : 0);
+  return ((x & 0xAAAAAAAAAAAA) != 0 ? 1 : 0) |
+      ((x & 0xCCCCCCCCCCCC) != 0 ? 2 : 0) |
+      ((x & 0xF0F0F0F0F0F0) != 0 ? 4 : 0) |
+      ((x & 0xFF00FF00FF00) != 0 ? 8 : 0) |
+      ((x & 0x0000FFFF0000) != 0 ? 16 : 0) |
+      ((x & 0xFFFF00000000) != 0 ? 32 : 0);
 }
 
 /// Returns the smallest power of two equal or greater than [x].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: fftea
-version: 1.1.0+1
+version: 1.1.1
 description: >
   Fast Fourier Transform (FFT) library that can handle inputs of any size.
   Includes related tools such as STFT and windowing.

--- a/test/misc_test.dart
+++ b/test/misc_test.dart
@@ -116,8 +116,7 @@ void main() {
       throwsA(
         predicate(
           (e) =>
-              e is ArgumentError &&
-              e.message == 'FFT size is limited to 2^32.',
+              e is ArgumentError && e.message == 'FFT size is limited to 2^32.',
         ),
       ),
     );

--- a/test/misc_test.dart
+++ b/test/misc_test.dart
@@ -112,6 +112,16 @@ void main() {
       ),
     );
     expect(
+      () => FFT(0x100000001),
+      throwsA(
+        predicate(
+          (e) =>
+              e is ArgumentError &&
+              e.message == 'FFT size is limited to 2^32.',
+        ),
+      ),
+    );
+    expect(
       () => Radix2FFT(0),
       throwsA(
         predicate(

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -129,7 +129,7 @@ void main() {
   });
 
   test('highestBit', () {
-    for (int i = 0; i < 64; ++i) {
+    for (int i = 0; i < 48; ++i) {
       expect(highestBit(1 << i), i);
     }
   });


### PR DESCRIPTION
Also limit highestBit to 2^48. These changes ensure that the integer literals are all small enough for JS compatibility.

Fixes #17