### PR TITLE
Disable benchmark directory on CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,8 +45,6 @@ jobs:
     - id: install
       run: dart pub upgrade
     - run: dart pub upgrade
-      working-directory: bench
-    - run: dart pub upgrade
       working-directory: example
     - run: dart format --output=none --set-exit-if-changed .
       if: always() && steps.install.outcome == 'success'

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -15,8 +15,12 @@
 include: package:lints/recommended.yaml
 
 analyzer:
-  strong-mode:
-    implicit-casts: false
+  # Some of the libraries we benchmark haven't been ported to null safety, and
+  # likely never will be, so aren't compatible with dart 3.
+  exclude:
+    - bench/**
+  language:
+    strict-casts: true
 
 linter:
   rules:

--- a/bench/pubspec.yaml
+++ b/bench/pubspec.yaml
@@ -32,7 +32,3 @@ dependencies:
 
 dev_dependencies:
   lints: ^1.0.0
-
-analyzer:
-  exclude:
-    - ./**

--- a/bench/pubspec.yaml
+++ b/bench/pubspec.yaml
@@ -32,3 +32,7 @@ dependencies:
 
 dev_dependencies:
   lints: ^1.0.0
+
+analyzer:
+  exclude:
+    - ./**

--- a/bench/pubspec.yaml
+++ b/bench/pubspec.yaml
@@ -19,9 +19,9 @@ publish_to: 'none'
 
 version: 1.0.0
 
-# We import some legacy libraries for benchmarking, so allow older SDKs.
+# We import some legacy libraries for benchmarking, so use older SDKs.
 environment:
-  sdk: ">=2.7.0 <4.0.0"
+  sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
   fft: ^0.3.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,4 +30,4 @@ analyzer:
   exclude:
     # Some of the libraries we benchmark haven't been ported to null safety,
     # so aren't compatible with dart 3 (and likely never will be).
-    - bencmark/**
+    - bench/**

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,9 +25,3 @@ environment:
 dev_dependencies:
   lints: ^1.0.0
   test: ^1.20.2
-
-analyzer:
-  exclude:
-    # Some of the libraries we benchmark haven't been ported to null safety,
-    # so aren't compatible with dart 3 (and likely never will be).
-    - bench/**

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,3 +25,9 @@ environment:
 dev_dependencies:
   lints: ^1.0.0
   test: ^1.20.2
+
+analyzer:
+  exclude:
+    # Some of the libraries we benchmark haven't been ported to null safety,
+    # so aren't compatible with dart 3 (and likely never will be).
+    - bencmark/**


### PR DESCRIPTION
Some of the libraries we benchmark haven't been ported to null safety, so aren't compatible with dart 3 (and likely never will be).